### PR TITLE
[Bugfix] fix connector event handler

### DIFF
--- a/lib/quiltt_connector.dart
+++ b/lib/quiltt_connector.dart
@@ -145,8 +145,11 @@ class _WebViewPage {
       connectionId: uri.queryParameters['connectionId'],
       profileId: uri.queryParameters['profileId'],
     );
-    String eventType = uri.host;
-    switch (uri.host) {
+
+    // Normalize case to avoid case sensitivity issues
+    String eventType = uri.host.toLowerCase();
+
+    switch (eventType) {
       case 'load':
         controller.runJavaScript(initInjectedJavaScript);
         break;
@@ -194,8 +197,8 @@ class _WebViewPage {
             type: eventType, eventMetadata: eventMetadata));
         onExit?.call(ConnectorSDKOnEventExitCallback(
             type: eventType, eventMetadata: eventMetadata));
-        onExitAbort?.call(
-            ConnectorSDKOnExitAbortCallback(eventMetadata: eventMetadata));
+        onExitError?.call(
+            ConnectorSDKOnExitErrorCallback(eventMetadata: eventMetadata));
         _closeWebView();
         break;
       case 'authenticate':


### PR DESCRIPTION
<!--- CHANGELOG_START -->
## Improvements
- Enhanced the Flutter SDK's event handling to be more consistent across platforms by normalizing event type case before processing

## Bug Fixes
- Fixed a case-sensitivity issue in the Flutter SDK that prevented callbacks from firing correctly on iOS devices when receiving WebView events like `"ExitSuccess"`
- Fixed the error handling in Flutter SDK where `onExitAbort` was being called instead of `onExitError` for error events

<!--- CHANGELOG_END -->